### PR TITLE
Updated offline E2E tests

### DIFF
--- a/src/__tests__/offline/browser.spec.js
+++ b/src/__tests__/offline/browser.spec.js
@@ -47,6 +47,7 @@ tape('Browser offline mode', function (assert) {
 
   const config = {
     core: {
+      key: 'some_key',
       authorizationKey: 'localhost'
     },
     scheduler: {
@@ -109,10 +110,10 @@ tape('Browser offline mode', function (assert) {
 
     // Manager tests
     const expectedSplitView1 = {
-      name: 'testing_split', trafficType: null, killed: false, changeNumber: 0, treatments: ['on'], configs: {}
+      name: 'testing_split', trafficType: 'localhost', killed: false, changeNumber: 0, treatments: ['on'], configs: {}
     };
     const expectedSplitView2 = {
-      name: 'testing_split_with_config', trafficType: null, killed: false, changeNumber: 0, treatments: ['off'], configs: { off: '{ "color": "blue" }' }
+      name: 'testing_split_with_config', trafficType: 'localhost', killed: false, changeNumber: 0, treatments: ['off'], configs: { off: '{ "color": "blue" }' }
     };
     assert.deepEqual(manager.names(), ['testing_split', 'testing_split_with_config']);
     assert.deepEqual(manager.split('testing_split'), expectedSplitView1);
@@ -204,7 +205,7 @@ tape('Browser offline mode', function (assert) {
 
       // Manager tests
       const expectedSplitView3 = {
-        name: 'testing_split_with_config', trafficType: null, killed: false, changeNumber: 0, treatments: ['nope'], configs: {}
+        name: 'testing_split_with_config', trafficType: 'localhost', killed: false, changeNumber: 0, treatments: ['nope'], configs: {}
       };
       assert.deepEqual(manager.names(), ['testing_split', 'testing_split_2', 'testing_split_3', 'testing_split_with_config']);
       assert.deepEqual(manager.split('testing_split'), expectedSplitView1);

--- a/src/__tests__/offline/browser.spec.js
+++ b/src/__tests__/offline/browser.spec.js
@@ -47,7 +47,8 @@ tape('Browser offline mode', function (assert) {
 
   const config = {
     core: {
-      key: 'some_key',
+      // Although `key` is mandatory according to TypeScript declaration files,
+      // it can be omitted in LOCALHOST mode. In that case, the value `localhost_key` is used.
       authorizationKey: 'localhost'
     },
     scheduler: {

--- a/src/__tests__/offline/node.spec.js
+++ b/src/__tests__/offline/node.spec.js
@@ -249,15 +249,15 @@ function ManagerDotSplitTests(assert) {
     assert.deepEqual(manager.names(), ['testing_split', 'testing_split2', 'testing_split3']);
 
     const expectedView1 = {
-      name: 'testing_split', changeNumber: 0, killed: false, trafficType: null,
+      name: 'testing_split', changeNumber: 0, killed: false, trafficType: 'localhost',
       treatments: ['on'], configs: {}
     };
     const expectedView2 = {
-      name: 'testing_split2', changeNumber: 0, killed: false, trafficType: null,
+      name: 'testing_split2', changeNumber: 0, killed: false, trafficType: 'localhost',
       treatments: ['off'], configs: {}
     };
     const expectedView3 = {
-      name: 'testing_split3', changeNumber: 0, killed: false, trafficType: null,
+      name: 'testing_split3', changeNumber: 0, killed: false, trafficType: 'localhost',
       treatments: ['custom_treatment'], configs: {}
     };
 

--- a/src/utils/settings/index.js
+++ b/src/utils/settings/index.js
@@ -24,7 +24,7 @@ import integrations from './integrations';
 import mode from './mode';
 import validateSplitFilters from '../inputValidation/splitFilters';
 import { API } from '@splitsoftware/js-commons';
-import { STANDALONE_MODE, STORAGE_MEMORY, CONSUMER_MODE, OPTIMIZED } from '../../utils/constants';
+import { STANDALONE_MODE, STORAGE_MEMORY, CONSUMER_MODE, OPTIMIZED, LOCALHOST_MODE } from '../../utils/constants';
 import packageJSON from '../../../package.json';
 import validImpressionsMode from './impressionsMode';
 
@@ -149,6 +149,11 @@ function defaults(custom) {
 
   setupLogger(withDefaults.debug);
 
+  // Although `key` is mandatory according to TS declaration files, it can be omitted in LOCALHOST mode. In that case, the value `localhost_key` is used.
+  if (withDefaults.mode === LOCALHOST_MODE && withDefaults.core.key === undefined) {
+    withDefaults.core.key = 'localhost_key';
+  }
+
   // Current ip/hostname information
   withDefaults.runtime = runtime(withDefaults.core.IPAddressesEnabled, withDefaults.mode === CONSUMER_MODE);
 
@@ -196,24 +201,6 @@ const proto = {
     return `${this.urls.sdk}${target}`;
   },
 
-  /**
-   * Returns a settings clone with the key and traffic type (if provided) overriden.
-   * @param {SplitKey} key
-   * @param {string} [trafficType]
-   */
-  overrideKeyAndTT(key, trafficType) {
-    return objectAssign(
-      Object.create(proto),
-      this, {
-        core: objectAssign({},
-          this.core, {
-            key,
-            trafficType
-          }
-        )
-      }
-    );
-  }
 };
 
 const SettingsFactory = (settings) => objectAssign(Object.create(proto), defaults(settings));


### PR DESCRIPTION
# JS SDK

## What did you accomplish?

- Updated offline E2E tests: Offline SyncManager always sets the splits TT to `localhost`, so that the manager SplitView['trafficType'] can never be null as it is specified by type declarations.
- Updated settings validation function to set a default value (`localhost_key`) as user key if it is not provided in LOCALHOST mode.
- Removed `overrideKeyAndTT` method from settings, since it is not used anymore.

## To discuss

YES: overwrite undefined key anyway in LOCALHOST mode?

## Extra Notes