### PR TITLE
updated E2E tests

### DIFF
--- a/karma/config.js
+++ b/karma/config.js
@@ -52,9 +52,11 @@ module.exports = {
 
   webpack: {
     mode: 'production',
+
     /** Uncomment to debug with source files */
     // mode: 'development',
     // devtool: 'inline-source-map',
+
     module: {
       rules: [
         {
@@ -68,7 +70,9 @@ module.exports = {
                 'targets': {
                   'ie': '10',
                   'node': '6'
-                }
+                },
+                // Required for CJS build with TSC: https://babeljs.io/docs/en/babel-preset-env/#modules
+                'modules': 'commonjs'
               }]],
               plugins: [['@babel/plugin-transform-runtime', {
                 // default values

--- a/karma/config.js
+++ b/karma/config.js
@@ -52,6 +52,9 @@ module.exports = {
 
   webpack: {
     mode: 'production',
+    /** Uncomment to debug with source files */
+    // mode: 'development',
+    // devtool: 'inline-source-map',
     module: {
       rules: [
         {

--- a/src/__tests__/browser.spec.js
+++ b/src/__tests__/browser.spec.js
@@ -3,7 +3,7 @@ import fetchMock from './testUtils/fetchMock';
 import evaluationsSuite from './browserSuites/evaluations.spec';
 import impressionsSuite from './browserSuites/impressions.spec';
 import impressionsSuiteDebug from './browserSuites/impressions.debug.spec';
-import metricsSuite from './browserSuites/metrics.spec';
+// import metricsSuite from './browserSuites/metrics.spec';
 import impressionsListenerSuite from './browserSuites/impressions-listener.spec';
 import readinessSuite from './browserSuites/readiness.spec';
 import readyFromCache from './browserSuites/ready-from-cache.spec';
@@ -105,7 +105,8 @@ tape('## E2E CI Tests ##', function(assert) {
   /* Check impression listener */
   assert.test('E2E / Impression listener', impressionsListenerSuite);
   /* Check metrics */
-  assert.test('E2E / Metrics', metricsSuite.bind(null, fetchMock));
+  // @TODO uncomment when telemetry is implemented
+  // assert.test('E2E / Metrics', metricsSuite.bind(null, fetchMock));
   /* Check events */
   assert.test('E2E / Events', withoutBindingTT.bind(null, fetchMock));
   assert.test('E2E / Events with TT binded', bindingTT.bind(null, fetchMock));

--- a/src/__tests__/browserSuites/push-fallbacking.spec.js
+++ b/src/__tests__/browserSuites/push-fallbacking.spec.js
@@ -26,7 +26,7 @@ import authPushEnabledNicolasAndMarcio from '../mocks/auth.pushEnabled.nicolas@s
 
 import { nearlyEqual } from '../testUtils';
 
-import EventSourceMock, { setMockListener } from '../../sync/__tests__/mocks/eventSourceMock';
+import EventSourceMock, { setMockListener } from '../testUtils/eventSourceMock';
 window.EventSource = EventSourceMock;
 
 import { SplitFactory } from '../../index';

--- a/src/__tests__/browserSuites/push-initialization-nopush.spec.js
+++ b/src/__tests__/browserSuites/push-initialization-nopush.spec.js
@@ -117,18 +117,3 @@ export function testNoEventSource(fetchMock, assert) {
   window.EventSource = originalEventSource;
 
 }
-
-export function testNoBase64Support(fetchMock, assert) {
-  assert.plan(3);
-
-  const originalAtoB = window.atob;
-  window.atob = undefined;
-  fetchMock.getOnce(settings.url(`/auth?users=${encodeURIComponent(userKey)}`), function () {
-    assert.fail('not authenticate if `atob` or `btoa` functions are not available');
-  });
-
-  testInitializationFail(fetchMock, assert, false);
-
-  window.atob = originalAtoB;
-
-}

--- a/src/__tests__/browserSuites/push-initialization-retries.spec.js
+++ b/src/__tests__/browserSuites/push-initialization-retries.spec.js
@@ -7,7 +7,7 @@ import mySegmentsNicolasMock from '../mocks/mysegments.nicolas@split.io.json';
 
 import { nearlyEqual } from '../testUtils';
 
-import EventSourceMock, { setMockListener } from '../../sync/__tests__/mocks/eventSourceMock';
+import EventSourceMock, { setMockListener } from '../testUtils/eventSourceMock';
 
 import { SplitFactory } from '../../index';
 import SettingsFactory from '../../utils/settings';

--- a/src/__tests__/browserSuites/push-refresh-token.spec.js
+++ b/src/__tests__/browserSuites/push-refresh-token.spec.js
@@ -7,7 +7,7 @@ import authPushEnabledNicolas from '../mocks/auth.pushEnabled.nicolas@split.io.6
 import { nearlyEqual } from '../testUtils';
 
 // Replace original EventSource with mock
-import EventSourceMock, { setMockListener } from '../../sync/__tests__/mocks/eventSourceMock';
+import EventSourceMock, { setMockListener } from '../testUtils/eventSourceMock';
 window.EventSource = EventSourceMock;
 
 import { SplitFactory } from '../../index';

--- a/src/__tests__/browserSuites/push-synchronization-retries.spec.js
+++ b/src/__tests__/browserSuites/push-synchronization-retries.spec.js
@@ -12,10 +12,10 @@ import splitKillMessage from '../mocks/message.SPLIT_KILL.1457552650000.json';
 import authPushEnabledNicolas from '../mocks/auth.pushEnabled.nicolas@split.io.json';
 
 import { nearlyEqual } from '../testUtils';
-import Backoff from '../../utils/backoff';
+import Backoff from '@splitsoftware/js-commons/cjs/utils/Backoff';
 
 // Replace original EventSource with mock
-import EventSourceMock, { setMockListener } from '../../sync/__tests__/mocks/eventSourceMock';
+import EventSourceMock, { setMockListener } from '../testUtils/eventSourceMock';
 window.EventSource = EventSourceMock;
 
 import { SplitFactory } from '../../index';

--- a/src/__tests__/browserSuites/push-synchronization.spec.js
+++ b/src/__tests__/browserSuites/push-synchronization.spec.js
@@ -20,7 +20,7 @@ import { nearlyEqual } from '../testUtils';
 import includes from 'lodash/includes';
 
 // Replace original EventSource with mock
-import EventSourceMock, { setMockListener } from '../../sync/__tests__/mocks/eventSourceMock';
+import EventSourceMock, { setMockListener } from '../testUtils/eventSourceMock';
 window.EventSource = EventSourceMock;
 
 import { SplitFactory } from '../../index';

--- a/src/__tests__/gaIntegration/split-to-ga.spec.js
+++ b/src/__tests__/gaIntegration/split-to-ga.spec.js
@@ -319,7 +319,7 @@ export default function (fetchMock, assert) {
 
   });
 
-  // Split ready before GA initialized
+  // Split created before GA initialized
   assert.test(t => {
 
     const logSpy = sinon.spy(console, 'log');
@@ -334,13 +334,13 @@ export default function (fetchMock, assert) {
           const sentHitsDefault = window.gaSpy.getHits();
 
           t.equal(sentImpressions, numOfEvaluations, 'Number of impressions equals the number of evaluations');
-          t.equal(sentHitsDefault.length, 0, 'No hits sent if ga initialized after Split');
+          t.equal(sentHitsDefault.length, numOfEvaluations, 'Hits sent if ga initialized before Split evaluation (client.getTreatment***)');
 
           setTimeout(() => {
-            t.ok(logSpy.calledWith('[WARN]  splitio-split-to-ga => `ga` command queue not found. No hits will be sent.'));
-            client.destroy();
-            logSpy.restore();
-            t.end();
+            client.destroy().then(() => {
+              logSpy.restore();
+              t.end();
+            });
           });
         });
       });
@@ -353,6 +353,8 @@ export default function (fetchMock, assert) {
       ...config,
       debug: true,
     });
+    t.ok(logSpy.calledWith('[WARN]  splitio-split-to-ga => `ga` command queue not found. No hits will be sent until it is available.'), 'warning GA not found');
+
     client = factory.client();
     client.ready().then(() => {
       for (let i = 0; i < numOfEvaluations; i++)

--- a/src/__tests__/nodeSuites/push-fallbacking.spec.js
+++ b/src/__tests__/nodeSuites/push-fallbacking.spec.js
@@ -23,7 +23,7 @@ import authPushEnabled from '../mocks/auth.pushEnabled.node.json';
 
 import { nearlyEqual, mockSegmentChanges } from '../testUtils';
 
-import EventSourceMock, { setMockListener } from '../../sync/__tests__/mocks/eventSourceMock';
+import EventSourceMock, { setMockListener } from '../testUtils/eventSourceMock';
 import { __setEventSource } from '../../services/getEventSource/node';
 
 import { SplitFactory } from '../../index';

--- a/src/__tests__/nodeSuites/push-initialization-retries.spec.js
+++ b/src/__tests__/nodeSuites/push-initialization-retries.spec.js
@@ -6,7 +6,7 @@ import authPushBadToken from '../mocks/auth.pushBadToken.json';
 
 import { nearlyEqual } from '../testUtils';
 
-import EventSourceMock, { setMockListener } from '../../sync/__tests__/mocks/eventSourceMock';
+import EventSourceMock, { setMockListener } from '../testUtils/eventSourceMock';
 import { __setEventSource } from '../../services/getEventSource/node';
 
 import { SplitFactory } from '../../index';

--- a/src/__tests__/nodeSuites/push-refresh-token.spec.js
+++ b/src/__tests__/nodeSuites/push-refresh-token.spec.js
@@ -5,7 +5,7 @@ import authPushEnabled from '../mocks/auth.pushEnabled.node.601secs.json';
 
 import { nearlyEqual, mockSegmentChanges } from '../testUtils';
 
-import EventSourceMock, { setMockListener } from '../../sync/__tests__/mocks/eventSourceMock';
+import EventSourceMock, { setMockListener } from '../testUtils/eventSourceMock';
 import { __setEventSource } from '../../services/getEventSource/node';
 
 import { SplitFactory } from '../../index';

--- a/src/__tests__/nodeSuites/push-synchronization-retries.spec.js
+++ b/src/__tests__/nodeSuites/push-synchronization-retries.spec.js
@@ -10,9 +10,9 @@ import splitKillMessage from '../mocks/message.SPLIT_KILL.1457552650000.json';
 import authPushEnabled from '../mocks/auth.pushEnabled.node.json';
 
 import { nearlyEqual, mockSegmentChanges } from '../testUtils';
-import Backoff from '../../utils/backoff';
+import Backoff from '@splitsoftware/js-commons/cjs/utils/Backoff';
 
-import EventSourceMock, { setMockListener } from '../../sync/__tests__/mocks/eventSourceMock';
+import EventSourceMock, { setMockListener } from '../testUtils/eventSourceMock';
 import { __setEventSource } from '../../services/getEventSource/node';
 
 import { SplitFactory } from '../../index';

--- a/src/__tests__/nodeSuites/push-synchronization.spec.js
+++ b/src/__tests__/nodeSuites/push-synchronization.spec.js
@@ -12,7 +12,7 @@ import authPushEnabled from '../mocks/auth.pushEnabled.node.json';
 
 import { nearlyEqual, mockSegmentChanges } from '../testUtils';
 
-import EventSourceMock, { setMockListener } from '../../sync/__tests__/mocks/eventSourceMock';
+import EventSourceMock, { setMockListener } from '../testUtils/eventSourceMock';
 import { __setEventSource } from '../../services/getEventSource/node';
 
 import { SplitFactory } from '../../index';

--- a/src/__tests__/node_redis.spec.js
+++ b/src/__tests__/node_redis.spec.js
@@ -9,7 +9,7 @@ import RedisClient from 'ioredis';
 import { exec } from 'child_process';
 import { SplitFactory } from '../';
 import { merge } from '../utils/lang';
-import KeyBuilder from '../storage/Keys';
+import KeyBuilder from '@splitsoftware/js-commons/cjs/storages/KeyBuilderServerSide';
 import SettingsFactory from '../utils/settings';
 import { nearlyEqual } from './testUtils';
 
@@ -324,7 +324,7 @@ tape('NodeJS Redis', function (t) {
           // Redis client and keys required to check Redis store.
           const setting = SettingsFactory(config);
           const connection = new RedisClient(setting.storage.options.url);
-          const keys = new KeyBuilder(setting);
+          const keys = new KeyBuilder(setting.storage.prefix);
           const eventKey = keys.buildEventsKey();
           const impressionsKey = keys.buildImpressionsKey();
 

--- a/src/__tests__/node_redis.spec.js
+++ b/src/__tests__/node_redis.spec.js
@@ -9,7 +9,7 @@ import RedisClient from 'ioredis';
 import { exec } from 'child_process';
 import { SplitFactory } from '../';
 import { merge } from '../utils/lang';
-import KeyBuilder from '@splitsoftware/js-commons/cjs/storages/KeyBuilderServerSide';
+import KeyBuilderSS from '@splitsoftware/js-commons/cjs/storages/KeyBuilderSS';
 import SettingsFactory from '../utils/settings';
 import { nearlyEqual } from './testUtils';
 
@@ -324,7 +324,7 @@ tape('NodeJS Redis', function (t) {
           // Redis client and keys required to check Redis store.
           const setting = SettingsFactory(config);
           const connection = new RedisClient(setting.storage.options.url);
-          const keys = new KeyBuilder(setting.storage.prefix);
+          const keys = new KeyBuilderSS(setting.storage.prefix);
           const eventKey = keys.buildEventsKey();
           const impressionsKey = keys.buildImpressionsKey();
 

--- a/src/__tests__/push/browser.spec.js
+++ b/src/__tests__/push/browser.spec.js
@@ -1,6 +1,6 @@
 import tape from 'tape-catch';
 import fetchMock from '../testUtils/fetchMock';
-import { testAuthWithPushDisabled, testAuthWith401, testNoEventSource, testNoBase64Support } from '../browserSuites/push-initialization-nopush.spec';
+import { testAuthWithPushDisabled, testAuthWith401, testNoEventSource } from '../browserSuites/push-initialization-nopush.spec';
 import { testAuthRetries, testSSERetries, testSdkDestroyWhileAuthRetries, testSdkDestroyWhileAuthSuccess } from '../browserSuites/push-initialization-retries.spec';
 import { testSynchronization } from '../browserSuites/push-synchronization.spec';
 import { testSynchronizationRetries } from '../browserSuites/push-synchronization-retries.spec';
@@ -14,7 +14,6 @@ tape('## Browser JS - E2E CI Tests for PUSH ##', function (assert) {
   assert.test('E2E / PUSH initialization: auth with push disabled', testAuthWithPushDisabled.bind(null, fetchMock));
   assert.test('E2E / PUSH initialization: auth with 401', testAuthWith401.bind(null, fetchMock));
   assert.test('E2E / PUSH initialization: fallback to polling if EventSource is not available', testNoEventSource.bind(null, fetchMock));
-  assert.test('E2E / PUSH initialization: fallback to polling if EventSource is not available', testNoBase64Support.bind(null, fetchMock));
 
   assert.test('E2E / PUSH initialization: auth failures and then success', testAuthRetries.bind(null, fetchMock));
   assert.test('E2E / PUSH initialization: SSE connection failures and then success', testSSERetries.bind(null, fetchMock));

--- a/src/__tests__/testUtils/eventSourceMock.js
+++ b/src/__tests__/testUtils/eventSourceMock.js
@@ -1,0 +1,80 @@
+/**
+ * EventEmitter mock based on https://github.com/gcedo/eventsourcemock/blob/master/src/EventSource.js
+ *
+ * To setup the mock assign it to the window object.
+ * ```
+ *  import EventSource from 'eventsourcemock';
+ *  Object.defineProperty(window, 'EventSource', {
+ *    value: EventSource,
+ *  });
+ * ```
+ *
+ */
+
+import EventEmitter from 'events';
+
+const defaultOptions = {
+  withCredentials: false
+};
+
+export const sources = {};
+let __listener;
+export function setMockListener(listener) {
+  __listener = listener;
+}
+
+export default class EventSource {
+
+  constructor(
+    url,
+    configuration = defaultOptions
+  ) {
+    this.url = url;
+    this.withCredentials = configuration.withCredentials;
+    this.readyState = 0;
+    // eslint-disable-next-line no-undef
+    this.__emitter = new EventEmitter();
+    sources[url] = this;
+    if (__listener) setTimeout(__listener, 0, this);
+  }
+
+  addEventListener(eventName, listener) {
+    this.__emitter.addListener(eventName, listener);
+  }
+
+  removeEventListener(eventName, listener) {
+    this.__emitter.removeListener(eventName, listener);
+  }
+
+  close() {
+    this.readyState = 2;
+  }
+
+  // The following methods can be used to mock EventSource behavior and events
+  emit(eventName, messageEvent) {
+    this.__emitter.emit(eventName, messageEvent);
+  }
+
+  emitError(error) {
+    if (typeof this.onerror === 'function') {
+      this.onerror(error);
+    }
+  }
+
+  emitOpen() {
+    this.readyState = 1;
+    if (typeof this.onopen === 'function') {
+      this.onopen();
+    }
+  }
+
+  emitMessage(message) {
+    if (typeof this.onmessage === 'function') {
+      this.onmessage(message);
+    }
+  }
+}
+
+EventSource.CONNECTING = 0;
+EventSource.OPEN = 1;
+EventSource.CLOSED = 2;

--- a/src/platform/browser.js
+++ b/src/platform/browser.js
@@ -2,14 +2,14 @@ import { splitApiFactory } from '@splitsoftware/js-commons/cjs/services/splitApi
 import splitsParserFromSettings from '@splitsoftware/js-commons/cjs/sync/offline/splitsParser/splitsParserFromSettings';
 import { syncManagerOfflineFactory } from '@splitsoftware/js-commons/cjs/sync/syncManagerOffline';
 import { syncManagerOnlineFactory } from '@splitsoftware/js-commons/cjs/sync/syncManagerOnline';
-import pushManagerFactory from '@splitsoftware/js-commons/cjs/sync/pushManager/pushManager';
-import pollingManagerClientSideFactory from '@splitsoftware/js-commons/cjs/sync/polling/pollingManagerClientSide';
+import pushManagerFactory from '@splitsoftware/js-commons/cjs/sync/streaming/pushManager';
+import pollingManagerCSFactory from '@splitsoftware/js-commons/cjs/sync/polling/pollingManagerCS';
 import { InLocalStorageCSFactory } from '@splitsoftware/js-commons/cjs/storages/inLocalStorage/index';
 import { InMemoryStorageCSFactory } from '@splitsoftware/js-commons/cjs/storages/inMemory/InMemoryStorageCS';
 import { sdkManagerFactory } from '@splitsoftware/js-commons/cjs/sdkManager/index';
 import { sdkClientMethodCSFactory } from '@splitsoftware/js-commons/cjs/sdkClient/sdkClientMethodCS';
 import BrowserSignalListener from '@splitsoftware/js-commons/cjs/listeners/browser';
-import { clientSideObserverFactory } from '@splitsoftware/js-commons/cjs/trackers/impressionObserver/clientSideObserver';
+import { impressionObserverCSFactory } from '@splitsoftware/js-commons/cjs/trackers/impressionObserver/impressionObserverCS';
 import integrationsManagerFactory from '@splitsoftware/js-commons/cjs/integrations/browser';
 
 import getFetch from '../services/getFetch';
@@ -26,7 +26,7 @@ const browserPlatform = {
 };
 
 const syncManagerOfflineCSBrowserFactory = syncManagerOfflineFactory(splitsParserFromSettings);
-const syncManagerOnlineCSFactory = syncManagerOnlineFactory(pollingManagerClientSideFactory, pushManagerFactory);
+const syncManagerOnlineCSFactory = syncManagerOnlineFactory(pollingManagerCSFactory, pushManagerFactory);
 
 /**
  *
@@ -68,6 +68,6 @@ export function getModules(settings) {
 
     integrationsManagerFactory: settings.integrations && settings.integrations.length > 0 ? integrationsManagerFactory.bind(null, settings.integrations) : undefined,
 
-    impressionsObserverFactory: shouldAddPt(settings) ? clientSideObserverFactory : undefined,
+    impressionsObserverFactory: shouldAddPt(settings) ? impressionObserverCSFactory : undefined,
   };
 }

--- a/src/platform/browser.js
+++ b/src/platform/browser.js
@@ -1,11 +1,13 @@
 import { splitApiFactory } from '@splitsoftware/js-commons/cjs/services/splitApi';
 import splitsParserFromSettings from '@splitsoftware/js-commons/cjs/sync/offline/splitsParser/splitsParserFromSettings';
-import { syncManagerFactoryOfflineCS } from '@splitsoftware/js-commons/cjs/sync/syncManagerFactoryOfflineCS';
-import { syncManagerFactoryOnlineCS } from '@splitsoftware/js-commons/cjs/sync/syncManagerFactoryOnlineCS';
+import { syncManagerOfflineFactory } from '@splitsoftware/js-commons/cjs/sync/syncManagerOffline';
+import { syncManagerOnlineFactory } from '@splitsoftware/js-commons/cjs/sync/syncManagerOnline';
+import pushManagerFactory from '@splitsoftware/js-commons/cjs/sync/pushManager/pushManager';
+import pollingManagerClientSideFactory from '@splitsoftware/js-commons/cjs/sync/polling/pollingManagerClientSide';
 import { InLocalStorageCSFactory } from '@splitsoftware/js-commons/cjs/storages/inLocalStorage/index';
 import { InMemoryStorageCSFactory } from '@splitsoftware/js-commons/cjs/storages/inMemory/InMemoryStorageCS';
 import { sdkManagerFactory } from '@splitsoftware/js-commons/cjs/sdkManager/index';
-import { clientMethodCSFactory } from '@splitsoftware/js-commons/cjs/sdkClient/clientMethodCS';
+import { sdkClientMethodCSFactory } from '@splitsoftware/js-commons/cjs/sdkClient/sdkClientMethodCS';
 import BrowserSignalListener from '@splitsoftware/js-commons/cjs/listeners/browser';
 import { clientSideObserverFactory } from '@splitsoftware/js-commons/cjs/trackers/impressionObserver/clientSideObserver';
 import integrationsManagerFactory from '@splitsoftware/js-commons/cjs/integrations/browser';
@@ -23,7 +25,8 @@ const browserPlatform = {
   getOptions
 };
 
-const syncManagerFactoryOfflineCSBrowser = syncManagerFactoryOfflineCS.bind(null, splitsParserFromSettings);
+const syncManagerOfflineCSBrowserFactory = syncManagerOfflineFactory(splitsParserFromSettings);
+const syncManagerOnlineCSFactory = syncManagerOnlineFactory(pollingManagerClientSideFactory, pushManagerFactory);
 
 /**
  *
@@ -56,10 +59,10 @@ export function getModules(settings) {
 
 
     splitApiFactory: settings.mode === 'localhost' ? undefined : splitApiFactory,
-    syncManagerFactory: settings.mode === 'localhost' ? syncManagerFactoryOfflineCSBrowser : syncManagerFactoryOnlineCS,
+    syncManagerFactory: settings.mode === 'localhost' ? syncManagerOfflineCSBrowserFactory : syncManagerOnlineCSFactory,
 
     sdkManagerFactory,
-    sdkClientMethodFactory: clientMethodCSFactory,
+    sdkClientMethodFactory: sdkClientMethodCSFactory,
     SignalListener: settings.mode === 'localhost' ? undefined : BrowserSignalListener,
     impressionListener: settings.impressionListener,
 

--- a/src/platform/browser.js
+++ b/src/platform/browser.js
@@ -1,7 +1,6 @@
 import { splitApiFactory } from '@splitsoftware/js-commons/cjs/services/splitApi';
 import splitsParserFromSettings from '@splitsoftware/js-commons/cjs/sync/offline/splitsParser/splitsParserFromSettings';
 import { syncManagerFactoryOfflineCS } from '@splitsoftware/js-commons/cjs/sync/syncManagerFactoryOfflineCS';
-// @TODO implement
 import { syncManagerFactoryOnlineCS } from '@splitsoftware/js-commons/cjs/sync/syncManagerFactoryOnlineCS';
 import { InLocalStorageCSFactory } from '@splitsoftware/js-commons/cjs/storages/inLocalStorage/index';
 import { InMemoryStorageCSFactory } from '@splitsoftware/js-commons/cjs/storages/inMemory/InMemoryStorageCS';

--- a/src/platform/node.js
+++ b/src/platform/node.js
@@ -1,11 +1,13 @@
 import { splitApiFactory } from '@splitsoftware/js-commons/cjs/services/splitApi';
 import splitsParserFromFile from '@splitsoftware/js-commons/cjs/sync/offline/splitsParser/splitsParserFromFile';
-import { syncManagerFactoryOffline } from '@splitsoftware/js-commons/cjs/sync/syncManagerFactoryOffline';
-import { syncManagerFactoryOnline } from '@splitsoftware/js-commons/cjs/sync/syncManagerFactoryOnline';
+import { syncManagerOfflineFactory } from '@splitsoftware/js-commons/cjs/sync/syncManagerOffline';
+import { syncManagerOnlineFactory } from '@splitsoftware/js-commons/cjs/sync/syncManagerOnline';
+import pushManagerFactory from '@splitsoftware/js-commons/cjs/sync/pushManager/pushManager';
+import pollingManagerServerSideFactory from '@splitsoftware/js-commons/cjs/sync/polling/pollingManagerServerSide';
 import { InRedisStorageFactory } from '@splitsoftware/js-commons/cjs/storages/inRedis/index';
 import { InMemoryStorageFactory } from '@splitsoftware/js-commons/cjs/storages/inMemory/InMemoryStorage';
 import { sdkManagerFactory } from '@splitsoftware/js-commons/cjs/sdkManager/index';
-import { clientMethodFactory } from '@splitsoftware/js-commons/cjs/sdkClient/clientMethod';
+import { sdkClientMethodFactory } from '@splitsoftware/js-commons/cjs/sdkClient/sdkClientMethod';
 import NodeSignalListener from '@splitsoftware/js-commons/cjs/listeners/node';
 import { serverSideObserverFactory } from '@splitsoftware/js-commons/cjs/trackers/impressionObserver/serverSideObserver';
 
@@ -20,7 +22,8 @@ const nodePlatform = {
   getEventSource,
 };
 
-const syncManagerFactoryOfflineNode = syncManagerFactoryOffline.bind(null, splitsParserFromFile);
+const syncManagerOfflineNodeFactory = syncManagerOfflineFactory(splitsParserFromFile);
+const syncManagerOnlineSSFactory = syncManagerOnlineFactory(pollingManagerServerSideFactory, pushManagerFactory);
 
 /**
  *
@@ -52,10 +55,10 @@ export function getModules(settings) {
       }),
 
     splitApiFactory: settings.mode === 'localhost' ? undefined : splitApiFactory,
-    syncManagerFactory: settings.storage.type === 'REDIS' ? undefined : settings.mode === 'localhost' ? syncManagerFactoryOfflineNode : syncManagerFactoryOnline,
+    syncManagerFactory: settings.storage.type === 'REDIS' ? undefined : settings.mode === 'localhost' ? syncManagerOfflineNodeFactory : syncManagerOnlineSSFactory,
 
     sdkManagerFactory,
-    sdkClientMethodFactory: clientMethodFactory,
+    sdkClientMethodFactory: sdkClientMethodFactory,
     SignalListener: settings.mode === 'localhost' ? undefined : NodeSignalListener,
     impressionListener: settings.impressionListener,
 

--- a/src/platform/node.js
+++ b/src/platform/node.js
@@ -2,14 +2,14 @@ import { splitApiFactory } from '@splitsoftware/js-commons/cjs/services/splitApi
 import splitsParserFromFile from '@splitsoftware/js-commons/cjs/sync/offline/splitsParser/splitsParserFromFile';
 import { syncManagerOfflineFactory } from '@splitsoftware/js-commons/cjs/sync/syncManagerOffline';
 import { syncManagerOnlineFactory } from '@splitsoftware/js-commons/cjs/sync/syncManagerOnline';
-import pushManagerFactory from '@splitsoftware/js-commons/cjs/sync/pushManager/pushManager';
-import pollingManagerServerSideFactory from '@splitsoftware/js-commons/cjs/sync/polling/pollingManagerServerSide';
+import pushManagerFactory from '@splitsoftware/js-commons/cjs/sync/streaming/pushManager';
+import pollingManagerSSFactory from '@splitsoftware/js-commons/cjs/sync/polling/pollingManagerSS';
 import { InRedisStorageFactory } from '@splitsoftware/js-commons/cjs/storages/inRedis/index';
 import { InMemoryStorageFactory } from '@splitsoftware/js-commons/cjs/storages/inMemory/InMemoryStorage';
 import { sdkManagerFactory } from '@splitsoftware/js-commons/cjs/sdkManager/index';
 import { sdkClientMethodFactory } from '@splitsoftware/js-commons/cjs/sdkClient/sdkClientMethod';
 import NodeSignalListener from '@splitsoftware/js-commons/cjs/listeners/node';
-import { serverSideObserverFactory } from '@splitsoftware/js-commons/cjs/trackers/impressionObserver/serverSideObserver';
+import { impressionObserverSSFactory } from '@splitsoftware/js-commons/cjs/trackers/impressionObserver/impressionObserverSS';
 
 import getFetch from '../services/getFetch';
 import getEventSource from '../services/getEventSource';
@@ -23,7 +23,7 @@ const nodePlatform = {
 };
 
 const syncManagerOfflineNodeFactory = syncManagerOfflineFactory(splitsParserFromFile);
-const syncManagerOnlineSSFactory = syncManagerOnlineFactory(pollingManagerServerSideFactory, pushManagerFactory);
+const syncManagerOnlineSSFactory = syncManagerOnlineFactory(pollingManagerSSFactory, pushManagerFactory);
 
 /**
  *
@@ -62,6 +62,6 @@ export function getModules(settings) {
     SignalListener: settings.mode === 'localhost' ? undefined : NodeSignalListener,
     impressionListener: settings.impressionListener,
 
-    impressionsObserverFactory: shouldAddPt(settings) ? serverSideObserverFactory : undefined,
+    impressionsObserverFactory: shouldAddPt(settings) ? impressionObserverSSFactory : undefined,
   };
 }

--- a/src/platform/node.js
+++ b/src/platform/node.js
@@ -29,13 +29,21 @@ const syncManagerFactoryOfflineNode = syncManagerFactoryOffline.bind(null, split
 export function getModules(settings) {
   return {
     settings,
-    // @TODO add type to ISettings
+    // @TODO add type to ISettings?
     filterQueryString: settings.sync.__splitFiltersValidation.queryString,
 
 
     platform: nodePlatform,
     storageFactory: settings.storage.type === 'REDIS' ?
-      InRedisStorageFactory :
+      InRedisStorageFactory.bind(null, {
+        prefix: settings.storage.prefix,
+        metadata: {
+          version: settings.version,
+          ip: settings.runtime.ip,
+          hostname: settings.runtime.hostname
+        },
+        options: settings.storage.options
+      }) :
       InMemoryStorageFactory.bind(null, {
         eventsQueueSize: settings.scheduler.eventsQueueSize,
         debugImpressionsMode: shouldBeOptimized(settings) ? false : true,
@@ -44,7 +52,7 @@ export function getModules(settings) {
       }),
 
     splitApiFactory: settings.mode === 'localhost' ? undefined : splitApiFactory,
-    syncManagerFactory: settings.mode === 'localhost' ? syncManagerFactoryOfflineNode : syncManagerFactoryOnline,
+    syncManagerFactory: settings.storage.type === 'REDIS' ? undefined : settings.mode === 'localhost' ? syncManagerFactoryOfflineNode : syncManagerFactoryOnline,
 
     sdkManagerFactory,
     sdkClientMethodFactory: clientMethodFactory,

--- a/src/utils/settings/index.js
+++ b/src/utils/settings/index.js
@@ -23,7 +23,7 @@ import storage from './storage';
 import integrations from './integrations';
 import mode from './mode';
 import validateSplitFilters from '../inputValidation/splitFilters';
-import { API } from '@splitsoftware/js-commons';
+import { API } from '@splitsoftware/js-commons/cjs/logger/sdkLogger';
 import { STANDALONE_MODE, STORAGE_MEMORY, CONSUMER_MODE, OPTIMIZED, LOCALHOST_MODE } from '../../utils/constants';
 import packageJSON from '../../../package.json';
 import validImpressionsMode from './impressionsMode';


### PR DESCRIPTION
Changes:
- Updated SplitToGa E2E tests, since now the integration checks `ga` availability per each tracked event/impression.
- Removed `testNoBase64Support` Browser E2E test, since Base64 utils are now included in JS-commons, for browser, node or any other environment.
- Updated `readiness` Browser E2E test to: 
  - reduce execution time
  - consider additional corner-cases for smart ready and smart pausing logic (e.g., creating a new client on a different event-loop tick from the main client).

To do: 
- migrate Telemetry E2E tests.
- migrate DataLoader E2E tests.